### PR TITLE
Update MetricsEndpointResponse encoding to UTF-8 (without BOM)

### DIFF
--- a/Src/Metrics.NET.Prometheus/PrometheusReportExtensions.cs
+++ b/Src/Metrics.NET.Prometheus/PrometheusReportExtensions.cs
@@ -17,7 +17,8 @@ namespace Metrics.NET.Prometheus
         /// <returns></returns>
         public static MetricsEndpointReports WithPrometheusEndpointReport(this MetricsEndpointReports config, string path = "/prometheus")
         {
-            return WithPrometheusEndpointReport(config, path, Encoding.ASCII);
+            Encoding utf8WithoutBom = new UTF8Encoding(false);
+            return WithPrometheusEndpointReport(config, path, utf8WithoutBom);
         }
 
         /// <summary>


### PR DESCRIPTION
Prometheus was not taking metrics from this endpoint because of the UTF-8-BOM encoding.
The issue is known at Prometheus repositories as seen here:
 - [Exposition format: Specify how to deal with UTF-8 BOMs](https://github.com/prometheus/docs/issues/542)
 - [Ignore UTF8 BOMs from funny windows clients](https://github.com/prometheus/common/pull/42)