### PR TITLE
Correcting the target framework and updating to Metrics.NET v0.5.5

### DIFF
--- a/Src/Metrics.NET.Prometheus/Metrics.NET.Prometheus.csproj
+++ b/Src/Metrics.NET.Prometheus/Metrics.NET.Prometheus.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Metrics.NET.Prometheus</RootNamespace>
     <AssemblyName>Metrics.NET.Prometheus</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -35,8 +36,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Metrics, Version=0.5.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Metrics.NET.0.5.1\lib\net45\Metrics.dll</HintPath>
+    <Reference Include="Metrics, Version=0.5.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Metrics.NET.0.5.5\lib\net45\Metrics.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Src/Metrics.NET.Prometheus/packages.config
+++ b/Src/Metrics.NET.Prometheus/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Metrics.NET" version="0.5.1" targetFramework="net452" />
+  <package id="Metrics.NET" version="0.5.5" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Correcting the target framework (from 4.5.2 to 4.5)
Updating dependency Metrics.NET (from v0.5.1 to v0.5.5)